### PR TITLE
Refactor event listings into JSON data

### DIFF
--- a/src/en/events.json
+++ b/src/en/events.json
@@ -1,0 +1,92 @@
+[
+  {
+    "titleHtml": "The Tenth Workshop",
+    "date": "12/22/2022",
+    "label": "NEW!",
+    "details": [
+      { "label": "Official language:", "content": "Japanese" },
+      { "label": "Where:", "content": "Online (Zoom)" },
+      { "label": "When:", "content": "12/22/2022 1:30pm- (<abbr title=\"Japan Standard Time\">JST</abbr>)" }
+    ],
+    "summary": "",
+    "link": "/en/10"
+  },
+  {
+    "titleHtml": "The Ninth Workshop",
+    "date": "3/23/2022",
+    "details": [
+      { "label": "Official language:", "content": "Japanese" },
+      { "label": "Where:", "content": "Online (Zoom)" },
+      { "label": "When:", "content": "3/23/2022 1:30pm-4pm (<abbr title=\"Japan Standard Time\">JST</abbr>)" }
+    ],
+    "summary": "",
+    "link": "/en/9"
+  },
+  {
+    "titleHtml": "The Eighth Workshop",
+    "date": "3/19/2021",
+    "details": [
+      { "label": "Official language:", "content": "Japanese" },
+      { "label": "Where:", "content": "Online" },
+      { "label": "When:", "content": "3/19/2021 11am-3:30pm (<abbr title=\"Japan Standard Time\">JST</abbr>)" }
+    ],
+    "summary": "",
+    "link": "/en/8"
+  },
+  {
+    "titleHtml": "The Seventh Workshop",
+    "date": "2/5/2020",
+    "details": [],
+    "summary": "Around 15 researchers including over half of students attended the event, introducing their latest research work. The attendees provided about 20min presentations and received feedback through discussions and Slack messages.",
+    "link": "/en/7"
+  },
+  {
+    "titleHtml": "The Sixth Workshop",
+    "date": "3/2/2019",
+    "details": [],
+    "summary": "The sixth workshop was held in conjunction with the NII Shonan meeting on <a href=\"https://shonan.nii.ac.jp/seminars/147/\">Self-supporting, Extensible Programming Languages and Environments for Exploratory, Live Software Development</a>.",
+    "link": "/en/6"
+  },
+  {
+    "titleHtml": "The Fifth Workshop",
+    "date": "12/3/2018",
+    "details": [],
+    "summary": "Around 20 researchers including over half of students attended the event, introducing their latest research work. The attendees provided 15min or 10min presentations and received feedback through 3 minutes of discussions and Slack messages.",
+    "link": "/en/5"
+  },
+  {
+    "titleHtml": "The Forth Workshop",
+    "date": "3/2/2018",
+    "details": [],
+    "summary": "Around 20 researchers including about half of students attended the event, introducing their latest research work in a simplified version of <a href=\"//dreamsongs.com/Files/WritersWorkshopTypeset.pdf\">the Writer's Workshop format</a>. Some attendees provided 15min presentations followed by 5 or more minutes of critiques, reviews, and general discussions. Others provided short (3min or more) lightning talks.",
+    "link": "/en/4"
+  },
+  {
+    "titleHtml": "<abbr title=\"Programming Experience\">PX</abbr> Special Issue in <abbr title=\"Information Processing Society of Japan\">IPSJ</abbr> Journal",
+    "date": "Nov. 2017",
+    "details": [],
+    "summary": "A special issue titled <strong>\"Emerging Research on Programming Experience: From Language Design to Industrial Applications\"</strong> collected seven articles that covered broad and latest topics in <abbr title=\"Programming Experience\">PX</abbr>, not only in academia (programming language, software engineering, and human-computer interaction) but also in startup and maker cultures, written by established professionals in the field.",
+    "link": "/en/ipsj2017"
+  },
+  {
+    "titleHtml": "The Third Workshop",
+    "date": "7/8/2017",
+    "details": [],
+    "summary": "Despite the short notice, around 10 researchers and engineers from the world attended the event, presenting their latest outcome and discussing the future of programming experience.",
+    "link": "/en/3"
+  },
+  {
+    "titleHtml": "The Second Workshop",
+    "date": "8/7/2016",
+    "details": [],
+    "summary": "30 researchers, engineers, and interaction designers dealing with programming languages, tools, integrated development environments attended the event, learning relevant research fields and industry efforts and getting to know each other through long (15-25min) and short (1-3min) introduction of their work.",
+    "link": "/en/2"
+  },
+  {
+    "titleHtml": "The First Workshop",
+    "date": "2/27/2016",
+    "details": [],
+    "summary": "36 researchers, engineers, and evangelists dealing with programming languages, tools, integrated development environments attended the event, getting to know each other through long (15min) and short (1min) introduction of their work.",
+    "link": "/en/1"
+  }
+]

--- a/src/en/index.pug
+++ b/src/en/index.pug
@@ -2,6 +2,7 @@ extends ../layout
 
 block vars
   - const path = 'en/';
+  - const events = JSON.parse(fs.readFileSync('src/en/events.json'));
 
 block description
   p SIGPX is a Japanese domestic study group for those interested in programming environments and their programming experience, founded in January 2016. We gather for exchanging information on state-of-the-art research and development projects relevant to programming experience.
@@ -35,133 +36,24 @@ block body
       strong anybody interested in Programming Experience
       | .
   section#events
-    h2
-      | The Tenth Workshop 
-      span.gray (12/22/2022)
-      |  
-      span.label NEW!
-    ul
-      li
-        strong Official language:
-        |  Japanese
-      li
-        strong Where:
-        |  Online (Zoom)
-      li
-        strong When:
-        |  12/22/2022 1:30pm- (
-        abbr(title='Japan Standard Time') JST
-        | )
-    //  <p class="details"><a href="https://forms.gle/yUWWRV6kMufkdV1WA" class="red">Register to attend &#9786;</a></p> 
-    p.details
-      a(href='/en/10') More Details? ☺
-      br
-    h2
-      | The Ninth Workshop 
-      span.gray (3/23/2022)
-    ul
-      li
-        strong Official language:
-        |  Japanese
-      li
-        strong Where:
-        |  Online (Zoom)
-      li
-        strong When:
-        |  3/23/2022 1:30pm-4pm (
-        abbr(title='Japan Standard Time') JST
-        | )
-    p.details
-      a(href='/en/9') More Details? ☺
-      br
-    h2
-      | The Eighth Workshop 
-      span.gray (3/19/2021)
-    ul
-      li
-        strong Official language:
-        |  Japanese
-      li
-        strong Where:
-        |  Online
-      li
-        strong When:
-        |  3/19/2021 11am-3:30pm (
-        abbr(title='Japan Standard Time') JST
-        | )
-    p.details
-      a(href='/en/8') More Details? ☺
-      br
-    h2
-      | The Seventh Workshop 
-      span.gray (2/5/2020)
-    p Around 15 researchers including over half of students attended the event, introducing their latest research work. The attendees provided about 20min presentations and received feedback through discussions and Slack messages.
-    p.details
-      a(href='/en/7') More Details? ☺
-      br
-    h2
-      | The Sixth Workshop 
-      span.gray (3/2/2019)
-    p
-      | The sixth workshop was held in conjunction with the NII Shonan meeting on 
-      a(href='https://shonan.nii.ac.jp/seminars/147/') Self-supporting, Extensible Programming Languages and Environments for Exploratory, Live Software Development
-      | .
-    p.details
-      a(href='/en/6') More Details? ☺
-      br
-    h2
-      | The Fifth Workshop 
-      span.gray (12/3/2018)
-    p Around 20 researchers including over half of students attended the event, introducing their latest research work. The attendees provided 15min or 10min presentations and received feedback through 3 minutes of discussions and Slack messages.
-    p.details
-      a(href='/en/5') More Details? ☺
-      br
-    h2
-      | The Forth Workshop 
-      span.gray (3/2/2018)
-    p
-      | Around 20 researchers including about half of students attended the event, introducing their latest research work in a simplified version of 
-      a(href='//dreamsongs.com/Files/WritersWorkshopTypeset.pdf') the Writer's Workshop format
-      | . Some attendees provided 15min presentations followed by 5 or more minutes of critiques, reviews, and general discussions. Others provided short (3min or more) lightning talks.
-    p.details
-      a(href='/en/4') More Details? ☺
-      br
-    h2
-      abbr(title='Programming Experience') PX
-      |  Special Issue in 
-      abbr(title='Information Processing Society of Japan') IPSJ
-      |  Journal 
-      span.gray (Nov. 2017)
-    p
-      | A special issue titled 
-      strong "Emerging Research on Programming Experience: From Language Design to Industrial Applications"
-      |  collected seven articles that covered broad and latest topics in 
-      abbr(title='Programming Experience') PX
-      | , not only in academia (programming language, software engineering, and human-computer interaction) but also in startup and maker cultures, written by established professionals in the field.
-    p.details
-      a.blue(href='/en/ipsj2017') More Details? ☺
-      br
-    h2
-      | The Third Workshop 
-      span.gray (7/8/2017)
-    p Despite the short notice, around 10 researchers and engineers from the world attended the event, presenting their latest outcome and discussing the future of programming experience.
-    p.details
-      a(href='/en/3') More Details? ☺
-      br
-    h2
-      | The Second Workshop 
-      span.gray (8/7/2016)
-    p 30 researchers, engineers, and interaction designers dealing with programming languages, tools, integrated development environments attended the event, learning relevant research fields and industry efforts and getting to know each other through long (15-25min) and short (1-3min) introduction of their work.
-    p.details
-      a(href='/en/2') More Details? ☺
-      br
-    h2
-      | The First Workshop 
-      span.gray (2/27/2016)
-    p 36 researchers, engineers, and evangelists dealing with programming languages, tools, integrated development environments attended the event, getting to know each other through long (15min) and short (1min) introduction of their work.
-    p.details
-      a(href='/en/1') More Details? ☺
-      br
+    each event in events
+      h2
+        != event.titleHtml
+        span.gray (#{event.date})
+        if event.label
+          != ' '
+          span.label= event.label
+      if event.details.length
+        ul
+          each detail in event.details
+            li
+              strong= detail.label
+              != ' ' + detail.content
+      if event.summary
+        p!= event.summary
+      p.details
+        a(href=event.link) More Details? ☺
+        br
   section#related-events
     h2 Relevant Events and Conferences
     dl

--- a/src/events.json
+++ b/src/events.json
@@ -1,0 +1,124 @@
+[
+  {
+    "id": "tenth-sigpx",
+    "title": "第10回",
+    "suffix": " 勉強会",
+    "label": "NEW!",
+    "details": [
+      { "label": "場所:", "content": "オンライン開催（Zoom）" },
+      { "label": "日時:", "content": "2022年12月22日（木）午後1時30分～午後4時" }
+    ],
+    "summary": "マイコン用開発環境、差分実行によるライブプログラミングの性能向上、深層学習の教育用ツールについての発表のほか、PX関連のDagstuhl Seminar 2回分の参加報告がありました。",
+    "link": { "href": "/10", "label": "第10回", "suffix": "の詳しい情報はこちら", "class": "" }
+  },
+  {
+    "id": "ninth-sigpx",
+    "title": "第9回",
+    "suffix": " 勉強会",
+    "details": [
+      { "label": "場所:", "content": "オンライン開催（Zoom）" },
+      { "label": "日時:", "content": "2022年3月23日（水）午後1時30分～午後4時" }
+    ],
+    "summary": "プログラミング教育、統合開発環境の拡張、言語処理系、メディアアート向けフレームワークやツールの提案について発表がありました。",
+    "link": { "href": "/9", "label": "第9回", "suffix": "の詳しい情報はこちら", "class": "" }
+  },
+  {
+    "id": "eighth-sigpx",
+    "title": "第8回",
+    "suffix": " 勉強会",
+    "details": [
+      { "label": "場所:", "content": "オンライン開催" },
+      { "label": "日時:", "content": "2021年3月19日（金）午前11時～午後3時30分" }
+    ],
+    "summary": "ライブプログラミングの新技術や音楽、グラフィックデザインのためのプログラミング環境などの研究紹介がありました。",
+    "link": { "href": "/8", "label": "第8回", "suffix": "の詳しい情報はこちら", "class": "" }
+  },
+  {
+    "id": "seventh-sigpx",
+    "title": "第7回",
+    "suffix": " 勉強会",
+    "details": [
+      { "label": "場所:", "content": "東京都渋谷区渋谷（詳細はSlackで告知）" },
+      { "label": "日時:", "content": "2020年2月5日（水）午後1時30分～午後5時" }
+    ],
+    "summary": "インタラクション研究や機械学習など、さまざまな分野について研究紹介や事例紹介を行いました。",
+    "link": { "href": "/7", "label": "第7回", "suffix": "の詳しい情報はこちら", "class": "" }
+  },
+  {
+    "id": "sixth-sigpx",
+    "title": "第6回",
+    "suffix": " 勉強会",
+    "details": [
+      { "label": "場所:", "content": "<a href=\"https://foundx.jp/about/\">FoundX</a>" },
+      { "label": "日時:", "content": "2019年3月2日（土）午前11時～午後1時" }
+    ],
+    "summary": "第6回は第147回 湘南会議「<a href=\"https://shonan.nii.ac.jp/seminars/147/\">Self-supporting, Extensible Programming Languages and Environments for Exploratory, Live Software Development</a>」にあわせて開催されました。日欧を中心に国際的な研究者が集まって研究内容を紹介しました。",
+    "link": { "href": "/6", "label": "第6回", "suffix": "の詳しい情報はこちら", "class": "" }
+  },
+  {
+    "id": "fifth-sigpx",
+    "title": "第5回",
+    "suffix": " 勉強会",
+    "details": [
+      { "label": "場所:", "content": "<a href=\"https://www.s.u-tokyo.ac.jp/ja/map/map06.html\">東京大学本郷キャンパス 理学部7号館</a> 2階202講義室" },
+      { "label": "日時:", "content": "2018年12月3日（月）午後2時～6時" }
+    ],
+    "summary": "プログラミング言語からインタラクション研究まで、ソフトウェアからハードウェアまで、幅広く盛りだくさんの勉強会となりました。",
+    "link": { "href": "/5", "label": "第5回", "suffix": "の詳しい情報はこちら", "class": "" }
+  },
+  {
+    "id": "forth-sigpx",
+    "title": "第4回",
+    "suffix": " 勉強会",
+    "details": [
+      { "label": "場所:", "content": "<a href=\"http://www.u-tokyo.ac.jp/campusmap/cam01_04_03_j.html\">東京大学本郷キャンパス 工学部2号館</a> 4階242講義室" },
+      { "label": "日時:", "content": "2018年3月2日（金）午後1時～6時" }
+    ],
+    "summary": "しっかり質疑や議論の時間も取りながら、研究発表やLightning Talkを行いました。今回から<a href=\"http://sigchi.jp/about.html\">Japan ACM SIGCHI Chapter</a>の共催となりました。",
+    "link": { "href": "/4", "label": "第4回", "suffix": "の詳しい情報はこちら", "class": "" }
+  },
+  {
+    "id": "ipsj2017",
+    "title": "「情報処理」小特集",
+    "suffix": " プログラミング・エクスペリエンスの新潮流",
+    "details": [
+      { "label": "掲載誌:", "content": "<a href=\"https://ipsj.ixsq.nii.ac.jp/ej/?action=repository_opensearch&index_id=8970\">情報処理学会 学会誌「情報処理」Vol.58 No.11</a>" },
+      { "label": "購入リンク:", "content": "<a href=\"https://www.fujisan.co.jp/product/1300001377/b/1578566/\">Fujisan.co.jp</a> / <a href=\"http://shop.ohmsha.co.jp/shop/shopdetail.html?brandcode=000000005130\">オーム社</a> / <a href=\"https://www.amazon.co.jp/dp/B075ZH5JF7/\">Amazon.co.jp</a>" }
+    ],
+    "summary": "本勉強会で扱ってきたさまざまなトピックをカバーした小特集が、情報処理学会の学会誌に掲載されました！",
+    "link": { "href": "/ipsj2017", "label": "学会誌連動ページ", "suffix": "はこちら", "class": "blue" }
+  },
+  {
+    "id": "third-sigpx",
+    "title": "第3回",
+    "suffix": " 勉強会",
+    "details": [
+      { "label": "場所:", "content": "東京工業大学 大岡山キャンパス 西8号館 W棟 10階 1008室" },
+      { "label": "日時:", "content": "2017年7月8日（土）午前11時～午後4時" }
+    ],
+    "summary": "開催予告から一週間以内の開催と忙しないスケジュールながら、さまざまな背景の人が集まり、研究紹介や事例紹介を行いました。",
+    "link": { "href": "/3", "label": "第3回", "suffix": "の詳しい情報はこちら", "class": "" }
+  },
+  {
+    "id": "second-sigpx",
+    "title": "第2回",
+    "suffix": " 勉強会",
+    "details": [
+      { "label": "場所:", "content": "<a href=\"https://www.microsoft.com/ja-jp/mscorp/branch/sgt.aspx\">日本マイクロソフト株式会社</a> 品川本社 31F セミナールームC+D（遠隔参加も可能）" },
+      { "label": "日時:", "content": "2016年8月7日（日）午前10時半～午後6時" }
+    ],
+    "summary": "前回同様、プログラミング言語やプログラミングを支援するツール、統合開発環境などを研究開発している研究者・エンジニアの方々を中心に集まり、自己紹介を兼ねて事例紹介を行いました。また、国際会議などの動向に関する報告セッションも設けました。",
+    "link": { "href": "/2", "label": "第2回", "suffix": "の詳しい情報はこちら", "class": "" }
+  },
+  {
+    "id": "first-sigpx",
+    "title": "第1回",
+    "suffix": " 勉強会",
+    "details": [
+      { "label": "場所:", "content": "東京工業大学 大岡山キャンパス 西8号館 W棟 10階 1008室（遠隔参加も可能）" },
+      { "label": "日時:", "content": "2016年2月27日（土）午前11時～午後6時" }
+    ],
+    "summary": "プログラミング言語やプログラミングを支援するツール、統合開発環境などを研究開発している研究者・エンジニアの方々を中心に集まり、自己紹介を兼ねて事例紹介を行いました。幅広い立場、分野の方の発表があり、懇親会まで議論が尽きませんでした。開催前より<a href=\"https://www.facebook.com/groups/sigpx\">Facebookグループ</a>で情報交換を行っていましたが、全体議論の内容も踏まえ、<a href=\"https://sigpx.slack.com\">Slack</a>の運用を始めました。",
+    "link": { "href": "/1", "label": "第1回", "suffix": "の詳しい情報はこちら", "class": "" }
+  }
+]

--- a/src/index.pug
+++ b/src/index.pug
@@ -2,6 +2,7 @@ extends ./layout
 
 block vars
   - const path = '';
+  - const events = JSON.parse(fs.readFileSync('src/events.json'));
 
 block description
   p SIGPXは、プログラミングのための環境と、その環境が提供する体験の設計に興味を持つ人で集まり、最新の研究動向や事例について情報交換する会です。
@@ -36,226 +37,27 @@ block body
         | Scrapbox
         span.long を見る・編集する
         | 📖
-  section#tenth-sigpx
-    h2
-      span.gray 第10回
-      |  勉強会 
-      span.label NEW!
-    ul
-      li
-        strong 場所:
-        |  オンライン開催（Zoom）
-      li
-        strong 日時:
-        |  2022年12月22日（木）午後1時30分～午後4時
-    //  <p>参加登録を受け付け中です。最新情報は<a href="https://join.slack.com/t/sigpx/shared_invite/enQtMzY5MzU0NjExNDU4LWVkNzljNTM2OGQxZTU2MDY0ZmNjMmIyZWFlYWYyMTFhYjA2NmZkYjg1NTYwYmRlYmU5YjJkMDc5ODJhNDE3Yzc">Slack</a>をご覧ください。</p> 
-    p マイコン用開発環境、差分実行によるライブプログラミングの性能向上、深層学習の教育用ツールについての発表のほか、PX関連のDagstuhl Seminar 2回分の参加報告がありました。
-    p.details
-      //  <a href="https://forms.gle/yUWWRV6kMufkdV1WA" class="red">参加登録する&#9786;</a> 
-      a(href='/10')
-        | 第10回
-        span.long の詳しい情報はこちら
-        | ☺
-  section#ninth-sigpx
-    h2
-      span.gray 第9回
-      |  勉強会
-    ul
-      li
-        strong 場所:
-        |  オンライン開催（Zoom）
-      li
-        strong 日時:
-        |  2022年3月23日（水）午後1時30分～午後4時
-    p プログラミング教育、統合開発環境の拡張、言語処理系、メディアアート向けフレームワークやツールの提案について発表がありました。
-    p.details
-      a(href='/9')
-        | 第9回
-        span.long の詳しい情報はこちら
-        | ☺
-  section#eighth-sigpx
-    h2
-      span.gray 第8回
-      |  勉強会
-    ul
-      li
-        strong 場所:
-        |  オンライン開催
-      li
-        strong 日時:
-        |  2021年3月19日（金）午前11時～午後3時30分
-    p ライブプログラミングの新技術や音楽、グラフィックデザインのためのプログラミング環境などの研究紹介がありました。
-    p.details
-      a(href='/8')
-        | 第8回
-        span.long の詳しい情報はこちら
-        | ☺
-  section#seventh-sigpx
-    h2
-      span.gray 第7回
-      |  勉強会
-    ul
-      li
-        strong 場所:
-        |  東京都渋谷区渋谷（詳細はSlackで告知）
-      li
-        strong 日時:
-        |  2020年2月5日（水）午後1時30分～午後5時
-    p インタラクション研究や機械学習など、さまざまな分野について研究紹介や事例紹介を行いました。
-    p.details
-      a(href='/7')
-        | 第7回
-        span.long の詳しい情報はこちら
-        | ☺
-  section#sixth-sigpx
-    h2
-      span.gray 第6回
-      |  勉強会
-    ul
-      li
-        strong 場所:
-        |  
-        a(href='https://foundx.jp/about/') FoundX
-      li
-        strong 日時:
-        |  2019年3月2日（土）午前11時～午後1時
-    p
-      | 第6回は第147回 湘南会議「
-      a(href='https://shonan.nii.ac.jp/seminars/147/') Self-supporting, Extensible Programming Languages and Environments for Exploratory, Live Software Development
-      | 」にあわせて開催されました。日欧を中心に国際的な研究者が集まって研究内容を紹介しました。
-    p.details
-      a(href='/6')
-        | 第6回
-        span.long の詳しい情報はこちら
-        | ☺
-  section#fifth-sigpx
-    h2
-      span.gray 第5回
-      |  勉強会
-    ul
-      li
-        strong 場所:
-        |  
-        a(href='https://www.s.u-tokyo.ac.jp/ja/map/map06.html') 東京大学本郷キャンパス 理学部7号館
-        |  2階202講義室
-      li
-        strong 日時:
-        |  2018年12月3日（月）午後2時～6時
-    p プログラミング言語からインタラクション研究まで、ソフトウェアからハードウェアまで、幅広く盛りだくさんの勉強会となりました。
-    p.details
-      a(href='/5')
-        | 第5回
-        span.long の詳しい情報はこちら
-        | ☺
-  section#forth-sigpx
-    h2
-      span.gray 第4回
-      |  勉強会
-    ul
-      li
-        strong 場所:
-        |  
-        a(href='http://www.u-tokyo.ac.jp/campusmap/cam01_04_03_j.html') 東京大学本郷キャンパス 工学部2号館
-        |  4階242講義室
-      li
-        strong 日時:
-        |  2018年3月2日（金）午後1時～6時
-    p
-      | しっかり質疑や議論の時間も取りながら、研究発表やLightning Talkを行いました。今回から
-      a(href='http://sigchi.jp/about.html') Japan ACM SIGCHI Chapter
-      | の共催となりました。
-    p.details
-      a(href='/4')
-        | 第4回
-        span.long の詳しい情報はこちら
-        | ☺
-  section#ipsj2017
-    h2
-      span.gray 「情報処理」小特集
-      |  プログラミング・エクスペリエンスの新潮流
-    ul
-      li
-        strong 掲載誌:
-        |  
-        a(href='https://ipsj.ixsq.nii.ac.jp/ej/?action=repository_opensearch&index_id=8970') 情報処理学会 学会誌「情報処理」Vol.58 No.11
-      li
-        strong 購入リンク:
-        |  
-        a(href='https://www.fujisan.co.jp/product/1300001377/b/1578566/') Fujisan.co.jp
-        |  / 
-        a(href='http://shop.ohmsha.co.jp/shop/shopdetail.html?brandcode=000000005130') オーム社
-        |  / 
-        a(href='https://www.amazon.co.jp/dp/B075ZH5JF7/') Amazon.co.jp
-    p 本勉強会で扱ってきたさまざまなトピックをカバーした小特集が、情報処理学会の学会誌に掲載されました！
-    p.details
-      a.blue(href='/ipsj2017')
-        | 学会誌連動ページ
-        span.long はこちら
-        | ☺
-  section#third-sigpx
-    h2
-      span.gray 第3回
-      |  勉強会
-    ul
-      li
-        strong 場所:
-        |  東京工業大学 大岡山キャンパス 西8号館 W棟 10階 1008室
-      li
-        strong 日時:
-        |  2017年7月8日（土）午前11時～午後4時
-    p 開催予告から一週間以内の開催と忙しないスケジュールながら、さまざまな背景の人が集まり、研究紹介や事例紹介を行いました。
-    p.details
-      a(href='/3')
-        | 第3回
-        span.long の詳しい情報はこちら
-        | ☺
-  section#second-sigpx
-    h2
-      span.gray 第2回
-      |  勉強会
-    ul
-      li
-        strong 場所:
-        |  
-        a(href='https://www.microsoft.com/ja-jp/mscorp/branch/sgt.aspx') 日本マイクロソフト株式会社
-        |  品川本社 31F セミナールームC+D（遠隔参加も可能）
-      li
-        strong 日時:
-        |  2016年8月7日（日）午前10時半～午後6時
-    p 前回同様、プログラミング言語やプログラミングを支援するツール、統合開発環境などを研究開発している研究者・エンジニアの方々を中心に集まり、自己紹介を兼ねて事例紹介を行いました。また、国際会議などの動向に関する報告セッションも設けました。
-    p.details
-      a(href='/2')
-        | 第2回
-        span.long の詳しい情報はこちら
-        | ☺
-    //
-      
-      <p>参加には以下のリンク（ボタン）から事前登録が必要です。最新情報は<a href="https://sigpx.slack.com">Slack</a>で確認するのが確実です。Slackに参加するには、<a href="https://join.slack.com/t/sigpx/shared_invite/enQtMzY5MzU0NjExNDU4LTZkN2U3Yjc2M2I3ZDAzMzUyN2E2NThlNDE0ZGZjMDkyNGUwNzVhMzBmMDY5YTNkMTY0YWQyN2JkMjBkMzYwNTU">招待リンク</a>にメールアドレスを記入して招待メールを受け取ってください。フォームが使えない場合は<a href="" id="apply-mail">メール</a>でご連絡ください。</p>
-      <p class="register"><a href="https://goo.gl/forms/0bcuaRn3ZgxrRiWL2">第2回の参加申し込みはこちら&#9786;</a><br><strong>登録〆切: 8月2日（火）</strong></p>
-      
-  section#first-sigpx
-    h2
-      span.gray 第1回
-      |  勉強会
-    ul
-      li
-        strong 場所:
-        |  東京工業大学 大岡山キャンパス 西8号館 W棟 10階 1008室（遠隔参加も可能）
-      li
-        strong 日時:
-        |  2016年2月27日（土）午前11時～午後6時
-    p プログラミング言語やプログラミングを支援するツール、統合開発環境などを研究開発している研究者・エンジニアの方々を中心に集まり、自己紹介を兼ねて事例紹介を行いました。
-    p
-      | 幅広い立場、分野の方の発表があり、懇親会まで議論が尽きませんでした。開催前より
-      a(href='https://www.facebook.com/groups/sigpx') Facebookグループ
-      | で情報交換を行っていましたが、全体議論の内容も踏まえ、
-      a(href='https://sigpx.slack.com') Slack
-      | の運用を始めました。
-    p.details
-      a(href='/1')
-        | 第1回
-        span.long の詳しい情報はこちら
-        | ☺
+  each event in events
+    section(id=event.id)
+      h2
+        span.gray= event.title
+        if event.suffix
+          | #{event.suffix}
+        if event.label
+          span.label= event.label
+      if event.details.length
+        ul
+          each detail in event.details
+            li
+              strong= detail.label
+              != ' ' + detail.content
+      if event.summary
+        p!= event.summary
+      p.details
+        a(href=event.link.href class=event.link.class)
+          | #{event.link.label}
+          span.long= event.link.suffix
+          | ☺
   section#related-events
     h2 関連しそうな学会・イベント
     dl


### PR DESCRIPTION
## Summary
- move Japanese and English event lists into `events.json`
- load event data in index pages and render dynamically

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b722d480808327841444128a8be36d